### PR TITLE
fix Invalid request

### DIFF
--- a/Core/SWeb3.php
+++ b/Core/SWeb3.php
@@ -82,15 +82,17 @@ class SWeb3
 
     function call($method, $params = null)
     {
-        if ($params != null) $params = $this->utils->forceAllNumbersHex($params);  
-
         //format api data
         $ethRequest = new Ethereum_CRPC();
         $ethRequest->id = 1;
         $ethRequest->jsonrpc = '2.0';
         $ethRequest->method = $method;
-        $ethRequest->params = $params;  
-        
+        if ($params != null) {
+            $ethRequest->params = $this->utils->forceAllNumbersHex($params);
+        } else {
+            $ethRequest->params = [];
+        }
+
         if ($this->do_batch) {
             $this->batched_calls []= $ethRequest;
             return true;


### PR DESCRIPTION
Some RPC services will return "Invalid request" when the param is null.

e.g
```json
// request
{"jsonrpc":"2.0","method":"eth_gasPrice","params":null,"id":1}

// response
{"jsonrpc":"2.0","id":null,"error":{"code":-32600,"message":"Invalid request"}}
```

this works

```json
{"jsonrpc":"2.0","method":"eth_gasPrice","params":[],"id":1}
```

