### PR TITLE
Fix hashing message with automatic detection of message is hex string

### DIFF
--- a/Core/Accounts.php
+++ b/Core/Accounts.php
@@ -25,9 +25,9 @@ class Account
 	public string $publicKey;
 	public string $address;
 
-	public function sign(string $message)
+	public function sign(string $message, bool $forceHex = false)
 	{ 
-		$hash = Accounts::hashMessage($message);  
+		$hash = Accounts::hashMessage($message, $forceHex);
 		$signature = $this->signRaw($hash);
 		$signature->message = $message;
 
@@ -127,13 +127,23 @@ class Accounts
 	}
   
 
-	public static function hashMessage(string $message) : string
+	public static function hashMessage(string $message, bool $forceHex = false) : string
 	{
-		//"\x19Ethereum Signed Message:\n" + message.length + message and hashed using keccak256. 
-		if (substr($message, 0, 2) == '0x') $message  = substr($message, 2);
-		if(ctype_xdigit($message)) $message = hex2bin($message);
+
+		if ($forceHex) {
+			if (substr($message, 0, 2) == '0x') {
+				$message  = substr($message, 2);
+				if (ctype_xdigit($message)) {
+					$message = hex2bin($message);
+				} else {
+					return "";
+				}
+			}
+
+		}
 
 		$msglen = strlen($message);
+		//"\x19Ethereum Signed Message:\n" + message.length + message and hashed using keccak256.
 		$msg    = hex2bin("19") . "Ethereum Signed Message:" . hex2bin("0A") . $msglen . $message;
 		$hash   = Keccak::hash($msg, 256);
 
@@ -141,7 +151,7 @@ class Accounts
 
 		//web3.eth.accounts.hashMessage("Hello World")
  		//"0xa1de988600a42c4b4ab089b619297c17d53cffae5d5120d82d8a92d0bb3b78f2" 
-	} 
+	}
 
 
 	public static function ecKeyToAddress($pubEcKey) : string


### PR DESCRIPTION
Message hashing must have no any automatic conversion of message.
If developer wants this transformation, it must be called with provided argument $forceHex = true