### PR TITLE
fix DecodeEvent when address type in indexed

### DIFF
--- a/Core/ABI.php
+++ b/Core/ABI.php
@@ -909,7 +909,7 @@ class ABI
 			{
 				$input_type = is_string($input) ? $input : $input->type;
 				$varType = self::GetParameterType($input_type);
-				$res->indexed[$input->name] = $this->DecodeInput_Generic($varType, $log->topics[$indexed_index], $varType === VariableType::Address ? 2 : 0);
+				$res->indexed[$input->name] = $this->DecodeInput_Generic($varType, $log->topics[$indexed_index], 2);
 
 				$indexed_index++;
 			}

--- a/Core/ABI.php
+++ b/Core/ABI.php
@@ -909,7 +909,7 @@ class ABI
 			{
 				$input_type = is_string($input) ? $input : $input->type;
 				$varType = self::GetParameterType($input_type);
-				$res->indexed[$input->name] = $this->DecodeInput_Generic($varType, $log->topics[$indexed_index], 0);
+				$res->indexed[$input->name] = $this->DecodeInput_Generic($varType, $log->topics[$indexed_index], $varType === VariableType::Address ? 2 : 0);
 
 				$indexed_index++;
 			}


### PR DESCRIPTION
Example: https://testnet.bscscan.com/tx/0xa63b427f49024386fe221a60f1b053cc4d6e1bc0710671b09a5a04e1fc6df8a5#eventlog with `StakingCreated` event

In the indexed, it started by `0x...`, so I must remove it to decode 