### PR TITLE
Remove bogus dynamic index increment

### DIFF
--- a/Core/ABI.php
+++ b/Core/ABI.php
@@ -340,7 +340,6 @@ class ABI
             $input->type = $input_type;
             $inputs []= $input; 
             $hashData .= self::EncodeInput($input, $element, 1, $currentDynamicIndex);  
-            $currentDynamicIndex += strlen($input->hash) / 2; 
         }
 
         foreach($inputs as $pos => $input) 


### PR DESCRIPTION
Hey there,

I was using the ABI EncodeData function to get raw data that I could submit over a websocket and stumbled upon that small issue.

The code is still working perfectly without it. I just removed the line as it was throwing a lot of warnings.

Basically, `$input->hash` is never defined, so the `$currentDynamicIndex` is always incremented by 0.

Thanks for that awesome library!