### PR TITLE
supports overloading

### DIFF
--- a/Core/ABI.php
+++ b/Core/ABI.php
@@ -66,6 +66,20 @@ class ABI
             }
             else if($func->type == 'function') {
                 $this->functions[$func->name] = $func; 
+                //////
+                $fname = $func->name;
+                if (!$func->inputs) {
+                    $fname .= '()';
+                } else {
+                    $p = [];
+                    // collect params
+                    foreach($func->inputs as $k => $v) {
+                        array_push($p, $v->type);
+                    }
+                    $fname .= '('.implode(",", $p).')';
+                }
+                $this->functions[$fname] = $func; 
+                /////
             } 
             else {
                 $this->other_objects []= $func; 


### PR DESCRIPTION
cann't call overloaded functions before
for example 
we have contract code with such functions:
```
function foo() {
}
function foo(uint x) {
}
function foo(uint x, uint y) {
}
```
**Actual:**
got error when trying to call `foo()` because pointing into last of list, i.e  `foo(uint x, uint y)`

**Expect:**
calling like this
```
$contract['foo()']();
$contract['foo(uint x)'](4);
$contract['foo(uint x,uint y)'](4,7);
```
and so on